### PR TITLE
Add auto syncing references

### DIFF
--- a/Contentless/Config.cs
+++ b/Contentless/Config.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -13,7 +14,9 @@ public class Config {
 
     [JsonProperty("overrides")]
     public Dictionary<string, Override> Overrides = new();
-
+    
+    [JsonProperty("references")] 
+    public string[] References = Array.Empty<string>();
 }
 
 public class Override {

--- a/Contentless/Contentless.csproj
+++ b/Contentless/Contentless.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <RollForward>Major</RollForward>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
     
     <PropertyGroup>
@@ -18,6 +19,12 @@
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1">
+            <PrivateAssets>All</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Build" Version="17.3.2">
+            <PrivateAssets>All</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="NuGet.Configuration" Version="6.8.0">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
     </ItemGroup>

--- a/Contentless/Contentless.nuspec
+++ b/Contentless/Contentless.nuspec
@@ -10,7 +10,7 @@
         <repository type="git" url="https://github.com/Ellpeck/Contentless" />
         <readme>README.md</readme>
         <icon>Logo.png</icon>
-        <version>3.0.7</version>
+        <version>3.0.8</version>
         <dependencies>
             <group targetFramework="net6.0" />
         </dependencies>

--- a/Contentless/Contentless.nuspec
+++ b/Contentless/Contentless.nuspec
@@ -10,7 +10,7 @@
         <repository type="git" url="https://github.com/Ellpeck/Contentless" />
         <readme>README.md</readme>
         <icon>Logo.png</icon>
-        <version>3.0.8</version>
+        <version>3.0.7</version>
         <dependencies>
             <group targetFramework="net6.0" />
         </dependencies>

--- a/Contentless/Contentless.targets
+++ b/Contentless/Contentless.targets
@@ -1,5 +1,5 @@
 <Project>
     <Target Name="Contentless" BeforeTargets="BeforeBuild">
-        <Exec Command="dotnet $(MSBuildThisFileDirectory)/../tools/Contentless.dll @(MonoGameContentReference)" />
+        <Exec Command="dotnet $(MSBuildThisFileDirectory)/../tools/Contentless.dll @(MonoGameContentReference) $(MSBuildProjectFullPath)" />
     </Target>
 </Project>

--- a/Contentless/NuGetHelper.cs
+++ b/Contentless/NuGetHelper.cs
@@ -1,0 +1,15 @@
+using NuGet.Configuration;
+
+namespace Contentless;
+
+public class NuGetHelper
+{
+    private readonly ISettings _settings;
+    
+    public NuGetHelper(string projectFolder)
+    {
+        _settings = Settings.LoadDefaultSettings(projectFolder);
+    }
+
+    public string PackageFolder => SettingsUtility.GetGlobalPackagesFolder(_settings);
+}

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -74,12 +74,12 @@ public static class Program {
         // load any references to be able to include custom content types as well
         for (int i = 0; i < content.Count; i++)
         {
-            const string REFERENCE_HEADER = "/reference:";
+            const string ReferenceHeader = "/reference:";
             
             var line = content[i];
-            if (!line.StartsWith(REFERENCE_HEADER))
+            if (!line.StartsWith(ReferenceHeader))
                 continue;
-            var reference = line.Substring(REFERENCE_HEADER.Length);
+            var reference = line.Substring(ReferenceHeader.Length);
             var libraryName = Path.GetFileName(reference)[..^4];
 
             if (referencesVersions.Keys.Contains(libraryName))
@@ -89,7 +89,7 @@ public static class Program {
                 {
                     Console.WriteLine($"Change library reference from {reference} to {fullLibraryPath}");
                     reference = fullLibraryPath;
-                    content[i] = REFERENCE_HEADER + fullLibraryPath;
+                    content[i] = ReferenceHeader + fullLibraryPath;
                     changed = true;
                 }
                 else

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -214,7 +214,9 @@ public static class Program {
         foreach (var property in projectRootElement.AllChildren.Where(x => x.ElementName == "PackageReference").Select(x => x as ProjectItemElement))
         {
             var libraryName = property.Include;
-            var version = (property.Children.First() as ProjectMetadataElement).Value;
+            if (property.Children.FirstOrDefault(x => x.ElementName == "Version") is not ProjectMetadataElement versionElement)
+                continue;
+            var version = versionElement.Value;
             if (referencesVersions.Keys.Contains(libraryName))
             {
                 referencesVersions[libraryName] = version;

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -7,7 +7,6 @@ using System.Text.RegularExpressions;
 using Microsoft.Build.Construction;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Newtonsoft.Json;
-using NuGet.Configuration;
 
 namespace Contentless;
 
@@ -47,8 +46,11 @@ public static class Program {
         var referencesVersions = config.References.ToDictionary(x => x, x => (string)null, StringComparer.OrdinalIgnoreCase);
         if (config.References.Length > 0)
         {
-            if (args.Length > 1) 
+            if (args.Length > 1)
+            {
                 ExtractVersions(args[1], referencesVersions);
+                _nuGetHelper = new NuGetHelper(Path.GetDirectoryName(args[1]));
+            }
             else
                 Console.Error.WriteLine("You supplied references but there is no project file, this isn't compatible. Please specify the full path of project file, if you want to sync references");
         }
@@ -233,10 +235,11 @@ public static class Program {
                 Console.Error.WriteLine($"Unable to find library {library.Key} in .csproj");
     }
 
+    private static NuGetHelper _nuGetHelper;
+
     private static string CalculateFullPathToLibrary(string libraryName, string referencesVersion)
     {
-        var settings = Settings.LoadDefaultSettings(null);
-        return Path.Combine(SettingsUtility.GetGlobalPackagesFolder(settings), libraryName.ToLower(), referencesVersion, "tools", libraryName + ".dll");
+        return Path.Combine(_nuGetHelper.PackageFolder, libraryName.ToLower(), referencesVersion, "tools", libraryName + ".dll");
     }
 
     private static (List<ImporterInfo>, List<string>) GetContentData() {

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -44,8 +44,8 @@ public static class Program {
         var excluded = config.ExcludedFiles.Select(Program.MakeFileRegex).ToArray();
         var overrides = Program.GetOverrides(config.Overrides).ToArray();
 
-        var referencesVersions = config.References.ToList().ToDictionary(x => x, x => (string)null, StringComparer.OrdinalIgnoreCase);
-        if (config.References.Any())
+        var referencesVersions = config.References.ToDictionary(x => x, x => (string)null, StringComparer.OrdinalIgnoreCase);
+        if (config.References.Length > 0)
         {
             var csprojPath = args[1];
             Console.WriteLine($"Using project file {csprojPath}");
@@ -54,11 +54,9 @@ public static class Program {
             {
                 var libraryName = property.Include;
                 var version = (property.Children.First() as ProjectMetadataElement).Value;
-                if (config.References.Any(x => x.Equals(libraryName, StringComparison.InvariantCultureIgnoreCase)))
                 if (referencesVersions.Keys.Contains(libraryName))
                 {
                     referencesVersions[libraryName] = version;
-                    //syncingReferences.Add(libraryName, version);
                     Console.WriteLine($"Found library version for sync: {libraryName}, {version}");
                 }
             }

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -87,7 +87,7 @@ public static class Program {
                 var fullLibraryPath = CalculateFullPathToLibrary(libraryName, referencesVersions[libraryName]);
                 if (reference != fullLibraryPath)
                 {
-                    Console.WriteLine($"Change library reference from {reference} to {fullLibraryPath}");
+                    Console.WriteLine($"Changing library reference from {reference} to {fullLibraryPath}");
                     reference = fullLibraryPath;
                     content[i] = ReferenceHeader + fullLibraryPath;
                     changed = true;

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -47,6 +47,10 @@ public static class Program {
         var referencesVersions = config.References.ToDictionary(x => x, x => (string)null, StringComparer.OrdinalIgnoreCase);
         if (config.References.Length > 0)
         {
+            if (args.Length < 2) {
+                Console.WriteLine("Please specify the full path of project file, you want to use");
+                return;
+            }
             var csprojPath = args[1];
             Console.WriteLine($"Using project file {csprojPath}");
             var projectRootElement = ProjectRootElement.Open(csprojPath);

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -48,7 +48,7 @@ public static class Program {
         if (config.References.Length > 0)
         {
             if (args.Length < 2) {
-                Console.WriteLine("Please specify the full path of project file, you want to use");
+                Console.WriteLine("You supplied references but there is no project file, this isn't compatible. Please specify the full path of project file, if you want to sync references");
                 return;
             }
             var csprojPath = args[1];

--- a/Contentless/Program.cs
+++ b/Contentless/Program.cs
@@ -44,10 +44,8 @@ public static class Program {
         var overrides = Program.GetOverrides(config.Overrides).ToArray();
 
         var referencesVersions = config.References.ToDictionary(x => x, x => (string)null, StringComparer.OrdinalIgnoreCase);
-        if (config.References.Length > 0)
-        {
-            if (args.Length > 1)
-            {
+        if (config.References.Length > 0) {
+            if (args.Length > 1) {
                 ExtractVersions(args[1], referencesVersions);
                 _nuGetHelper = new NuGetHelper(Path.GetDirectoryName(args[1]));
             }
@@ -59,19 +57,16 @@ public static class Program {
         var changed = false;
         var referencesSyncs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         // load any references to be able to include custom content types as well
-        for (int i = 0; i < content.Count; i++)
-        {
+        for (int i = 0; i < content.Count; i++) {
             var line = content[i];
             if (!line.StartsWith(ReferenceHeader))
                 continue;
             var reference = line.Substring(ReferenceHeader.Length);
             var libraryName = Path.GetFileName(reference)[..^4];
 
-            if (referencesVersions.TryGetValue(libraryName, out var version) && version is not null)
-            {
+            if (referencesVersions.TryGetValue(libraryName, out var version) && version is not null) {
                 var fullLibraryPath = CalculateFullPathToLibrary(libraryName, version);
-                if (reference != fullLibraryPath)
-                {
+                if (reference != fullLibraryPath) {
                     Console.WriteLine($"Changing library reference from {reference} to {fullLibraryPath}");
                     reference = fullLibraryPath;
                     content[i] = ReferenceHeader + fullLibraryPath;
@@ -96,18 +91,15 @@ public static class Program {
             if (line.StartsWith(ReferenceHeader))
                 referencesLastIndex = i + 1;
             else if (line.StartsWith("/importer:") || line.StartsWith("/processor:") || line.StartsWith("/build:") ||
-                     line.Contains("-- Content --"))
-            {
+                     line.Contains("-- Content --")) {
                 if (referencesLastIndex == 0)
                     referencesLastIndex = i;
                 break;
             }
         }
         foreach (var reference in referencesVersions)
-            if (!referencesSyncs.Contains(reference.Key) && reference.Value is not null)
-            {
-                try
-                {
+            if (!referencesSyncs.Contains(reference.Key) && reference.Value is not null) {
+                try {
                     var path = CalculateFullPathToLibrary(reference.Key, reference.Value);
                     content.Insert(referencesLastIndex++, ReferenceHeader + path);
                     changed = true;

--- a/Test/Content/Contentless.json
+++ b/Test/Content/Contentless.json
@@ -5,6 +5,7 @@
         "Ex*.png"
     ],
     "logSkipped": false,
+    "references": ["monogame.extended.content.pipeline"],
     "overrides": {
         "Copy.*": {
             "copy": true

--- a/Test/NuGet.Config
+++ b/Test/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        <add key="lithiumtoast" value="https://www.myget.org/F/lithiumtoast/api/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
Hi! I have added syncing for library references.

It successfully change reference on Windows. Please, check others if you can.

Now there are 2 point for thinking:
1. I use `Microsoft.Build ` for parsing versions. It can raise exception about old version this library, so version of this must be equal version this file in your .Net SDK. If this problem will have effect on users, we need implement it via XML.
2. I'm not sure adding reference is necessary so skip this.
Resolve #3 
