### PR TITLE
Update to MonoGame v3.8.4.1

### DIFF
--- a/Contentless/Contentless.csproj
+++ b/Contentless/Contentless.csproj
@@ -11,10 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.3">
+        <PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.4.1">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3">
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1">

--- a/Contentless/Contentless.nuspec
+++ b/Contentless/Contentless.nuspec
@@ -10,7 +10,7 @@
         <repository type="git" url="https://github.com/Ellpeck/Contentless" />
         <readme>README.md</readme>
         <icon>Logo.png</icon>
-        <version>4.2.0</version>
+        <version>4.2.1</version>
         <dependencies>
             <group targetFramework="net8.0" />
         </dependencies>


### PR DESCRIPTION
I noticed that external references that were using a newer MonoGame version would not be loaded correctly (in my case, [LDtkMonogame](https://github.com/IrishBruse/LDtkMonogame/tree/main)) and thus no new files using that library would be added to the `.mgcb` file. Upping the version inside of Contentless fixes this.